### PR TITLE
Fix rare miscalculation of dimensions on latest Chrome

### DIFF
--- a/jquery.vegas.js
+++ b/jquery.vegas.js
@@ -462,7 +462,7 @@
         }
 
         function imgLoaded() {
-            if ( --len <= 0 && this.src !== blank && this.height !== 0 ){
+            if ( --len <= 0 && this.src !== blank && ( $.browser.msie || this.height > 1 ) ){
                 setTimeout( triggerCallback );
                 $images.unbind( 'load error', imgLoaded );
             }


### PR DESCRIPTION
Hi, thanks for the wonderful work!
Under Chrome 18/Win, sometimes the slides were resized incorrectly because `$img.height()/width()` returned 0. This small change fixed the issue for me (now the load callback is only called after the image knows its dimensions).
