### PR TITLE
fix twitter bootstrap incompatibility

### DIFF
--- a/jquery.vegas.css
+++ b/jquery.vegas.css
@@ -22,3 +22,8 @@
 	-ms-interpolation-mode: bicubic;
 	z-index:-2;
 }
+
+img.vegas-background {
+    /* counteracts global img modification by twitter bootstrap library */
+    max-width: none !important;
+}


### PR DESCRIPTION
When using this plugin with twitters bootstrap library which modifies the global img declaration some miscalculation occur in the image width resulting in a non proportional image does not cover the complete background.
