### PR TITLE
Workaround for image dom element not fully loaded in the resize function causing incorrect image sizes

### DIFF
--- a/jquery.vegas.js
+++ b/jquery.vegas.js
@@ -340,6 +340,14 @@
         }
         $.extend( options, settings );
 
+    	if($img.height() == 0)
+		{
+			$img.load(function(){
+				resize($(this), settings);
+			});
+			return;
+		}
+
         var ww = $( window ).width(),
             wh = $( window ).height(),
             iw = $img.width(),


### PR DESCRIPTION
In Chrome (version 21) _some_ newly loaded images (ie images that have just been requested by browser for the first time), have a height/width of 0 in the resize method when called during the slideshow.  The added code ensures that the image is fully loaded before the resize logic runs.
