### PR TITLE
Apply image to element and pass initial settings on slideshow functions

### DIFF
--- a/dist/jquery.vegas.min.js
+++ b/dist/jquery.vegas.min.js
@@ -1,6 +1,6 @@
  // ----------------------------------------------------------------------------
  // Vegas - Fullscreen Backgrounds and Slideshows with jQuery.
- // v1.3.4 - released 2013-12-16 13:28
+ // v1.3.4 - released 2013-12-26 16:59
  // Licensed under the MIT license.
  // http://vegas.jaysalvat.com/
  // ----------------------------------------------------------------------------


### PR DESCRIPTION
Hello, 

First off, this is an amazing plugin, thank you so much for creating and sharing. This is the second time I use it and I needed to have the image within an element rather than the entire body so I have made some edits and thought you would like to check out and if you like, maybe even merge into your master. Also, on this push I added a $.vegas.defaults.init variable that stores the initial settings called when someone sets up a slideshow. The reason for this was, for example if I set up a slideshow with valign top (that was not being passed in - I applied a fix for that as well) and then I called next(), jump() or previous() all my original settings would not stick. So if my first slide was aligned to the top the one called by me executing the next() call would then get the default valign center.
