### PR TITLE
Fix 'TypeError' on destroy

### DIFF
--- a/src/vegas.js
+++ b/src/vegas.js
@@ -614,9 +614,12 @@
             this.$elmt.find('> .vegas-slide').remove();
             this.$elmt.find('> .vegas-wrapper').clone(true).children().appendTo(this.$elmt);
             this.$elmt.find('> .vegas-wrapper').remove();
-            this.$timer.remove();
-            this.$overlay.remove();
-
+            if (this.settings.timer) {
+              this.$timer.remove();    
+            }
+            if (this.settings.overlay) {
+              this.$overlay.remove();    
+            }
             this.elmt._vegas = null;
         }
     };


### PR DESCRIPTION
Prevents "TypeError" (cannot read property 'remove' of null) when $("myElem").vegas('destroy') is called and'timer' or 'overlay' settings are null or false.