### PR TITLE
Fix for unexpected toggle behavior

### DIFF
--- a/src/vegas.js
+++ b/src/vegas.js
@@ -528,9 +528,16 @@
             this.trigger('pause');
         },
 
+        resume: function () {
+            this.paused = false;
+            this._goto(this.slide);
+            this._timer(true);
+            this.trigger('resume');
+        },
+
         toggle: function () {
             if (this.paused) {
-                this.play();
+                this.resume();
             } else {
                 this.pause();
             }


### PR DESCRIPTION
- Added `resume` method to allow toggle functionality to work as expected
- Added call to `resume` instead of `play` in `toggle` method