### PR TITLE
Slide src pathnames that contain blank characters

### DIFF
--- a/src/vegas.js
+++ b/src/vegas.js
@@ -422,7 +422,7 @@
                 img = new Image();
 
                 $inner = $('<div class="vegas-slide-inner"></div>')
-                    .css('background-image',    'url(' + src + ')')
+                    .css('background-image',    'url("' + src + '")')
                     .css('background-color',    color)
                     .css('background-position', align + ' ' + valign);
 


### PR DESCRIPTION
@jaysalvat Please review this suggested code fix:-
This fix adds support for slide pathnames that contain blank characters in their name e.g. 
slides: [ { src: '/folder with blank in name/slide1.jpg' }, ... ],