### PR TITLE
Autplay Enabled - Jump to a specific slide fix

### DIFF
--- a/src/vegas.js
+++ b/src/vegas.js
@@ -541,7 +541,11 @@
         },
 
         _end: function () {
-            this.ended = true;
+            if (this.settings.autoplay) {
+                this.ended = false;
+            } else {
+                this.ended = true;
+            }
             this._timer(false);
             this.trigger('end');
         },


### PR DESCRIPTION
Before fix:
1. Enable Autoplay
2. Disable Loop
3. Go to last slide and wait for "end" state.
4. Execute $elmt.vegas('jump', any_slide_goes_here);
Result: Vegas will jump to specific slide but ***will not play*** next slide. It appears like autoplay is killed (which is sort of right due to _end function).

After fix:
1. Enable Autoplay
2. Disable Loop
3. Go to last slide and wait for "end" state.
4. Execute $elmt.vegas('jump', any_slide_goes_here);
Result: Vegas will jump to specific slide and after that it will autoplay next slide as it supposed to do.