### PR TITLE
fix sass compiler error

### DIFF
--- a/src/sass/transitions/blur.sass
+++ b/src/sass/transitions/blur.sass
@@ -5,12 +5,12 @@
 .vegas-transition-blur,
 .vegas-transition-blur2
     opacity: 0
-    filter: blur($vegas-blur-value) brightness(1.01);
+    filter: blur($vegas-blur-value) brightness(1.01)
 
 .vegas-transition-blur-in,
 .vegas-transition-blur2-in
     opacity: 1
-    filter: blur(0px) brightness(1.01);
+    filter: blur(0px) brightness(1.01)
 
 .vegas-transition-blur2-out
     opacity: 0


### PR DESCRIPTION
since semicolons are apparently banned in indented mode (or so the sass compiler told me today when I tried to pick up 2.4.3 :P)