### PR TITLE
Use relative url for overlay image

### DIFF
--- a/src/sass/main/vegas.sass
+++ b/src/sass/main/vegas.sass
@@ -20,7 +20,7 @@
 
 .vegas-overlay
     opacity: .5
-    background: transparent url('overlays/02.png') center center repeat
+    background: transparent url('./overlays/02.png') center center repeat
 
 .vegas-timer
     top: auto


### PR DESCRIPTION
So it can be correctly resolved when importing vegas.css by other processor (e.g. snowpack)